### PR TITLE
Remove reference to deprecated GtkDialog:has-separator property

### DIFF
--- a/src/vnr-properties-dialog.c
+++ b/src/vnr-properties-dialog.c
@@ -99,8 +99,7 @@ vnr_properties_dialog_new (VnrWindow *vnr_win, GtkAction *next_action, GtkAction
 {
     VnrPropertiesDialog *dialog;
 
-    dialog = g_object_new (VNR_TYPE_PROPERTIES_DIALOG,
-                           "has-separator", FALSE, NULL);
+    dialog = g_object_new (VNR_TYPE_PROPERTIES_DIALOG, NULL);
 
     dialog->thumbnail = NULL;
     dialog->vnr_win = vnr_win;


### PR DESCRIPTION
According to the gtk2 reference [1] the GtkDialog:has-separator property is deprecated since gtk 2.22, it defaults to the value FALSE which was set manually.

This is especially useful for gtk3 where this property might be removed. No side-effects expected since the property defaults to FALSE.

[1] https://developer.gnome.org/gtk2/stable/GtkDialog.html#GtkDialog--has-separator